### PR TITLE
Add Cracked.io

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -481,6 +481,13 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "Cracked.io": {
+    "errorType": "status_code",
+    "url": "https://cracked.io/{}",
+    "urlMain": "https://cracked.io/",
+    "username_claimed": "Blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Crevado": {
     "errorType": "status_code",
     "url": "https://{}.crevado.com",


### PR DESCRIPTION
Add Cracked.io - a popular skid hacker website

Examples of profiles:
Claimed: https://cracked.io/Blue - gives status code of 200 Unclaimed: https://cracked.io/noonewouldeverusethis7 - gives status code of 404